### PR TITLE
Readd changes, and fixies empty "Addon" list

### DIFF
--- a/AddonCategory.lua
+++ b/AddonCategory.lua
@@ -80,9 +80,15 @@ local function BuildMasterList(self)
 
 		entryData.isCustomCategory = false
 		if sV[entryData.addOnFileName] ~= nil then
-			entryData.isCustomCategory = true
+			-- I have a case with renamed base category after manually change the SavedVariables to unassigned
+			-- But I suppose can also happend if I install a pre-assigned addon
+			if self.addonTypes[sV[entryData.addOnFileName]] == nil then
+				entryData.isCustomCategory = false
+			else
+				entryData.isCustomCategory = true
+			end
 		end
-        
+
         if entryData.isCustomCategory == true then
 			self.addonTypes[IS_ADDON][i] = nil
             table.insert(self.addonTypes[sV[entryData.addOnFileName]], entryData)

--- a/AddonCategory.lua
+++ b/AddonCategory.lua
@@ -2,7 +2,10 @@ AddonCategory = AddonCategory or {}
 local AddonCategory = AddonCategory
 
 AddonCategory.name = "AddonCategory"
-AddonCategory.version = "1.5.2"
+AddonCategory.version = "1.5.1"
+AddonCategory.listAddons = {}
+AddonCategory.listLibraries = {}
+AddonCategory.listNonAssigned = {}
 
 local sV
 
@@ -13,6 +16,7 @@ local IS_LIBRARY = true
 local IS_ADDON = false
 
 local AddOnManager = GetAddOnManager()
+local votanAddonListPresent = false
 
 local expandedAddons = {}
 
@@ -30,91 +34,97 @@ local function StripText(text)
     return text:gsub("|c%x%x%x%x%x%x", "")
 end
 
+local function resetList()
+	AddonCategory.listAddons = {}
+    AddonCategory.listLibraries = {}
+    AddonCategory.listNonAssigned = {}
+end
+
+local function addAddonToList(index, name, isLibrary)
+	if isLibrary ~= IS_LIBRARY then
+		AddonCategory.listAddons[index] = name
+	else
+		AddonCategory.listLibraries[index] = name
+	end
+	
+	if sV[name] == nil and isLibrary ~= IS_LIBRARY then
+		table.insert(AddonCategory.listNonAssigned, name)
+	end
+end
+
+local function populateList()
+	resetList()
+
+	for i = 1, AddOnManager:GetNumAddOns() do
+		local name, _, _, _, _, _, _, isLibrary = AddOnManager:GetAddOnInfo(i)
+
+        addAddonToList(i, name, isLibrary)
+	end
+end
+
 local function BuildMasterList(self)
-    self.addonTypes = {}
-    self.addonTypes[IS_LIBRARY] = {}
-    self.addonTypes[IS_ADDON] = {}
+    self.addonTypes = self.addonTypes or {}
+    self.addonTypes[IS_ADDON] = self.addonTypes[IS_ADDON] or {}
     for key, value in pairs(sV.listCategory) do
         self.addonTypes[value] = {}
     end
 
-    if self.selectedCharacterEntry and not self.selectedCharacterEntry.allCharacters then
-        self.isAllFilterSelected = false
-        AddOnManager:SetAddOnFilter(CreateAddOnFilter(self.selectedCharacterEntry.name))
-    else
-        self.isAllFilterSelected = true
-        AddOnManager:RemoveAddOnFilter()
-    end
+    resetList()
 
-    AddonCategory.listAddons = {}
-    AddonCategory.listLibraries = {}
-    AddonCategory.listNonAssigned = {}
-    for i = 1, AddOnManager:GetNumAddOns() do
-        local name, title, author, description, enabled, state, isOutOfDate, isLibrary = AddOnManager:GetAddOnInfo(i)
-        if isLibrary ~= IS_LIBRARY then
-            AddonCategory.listAddons[i] = name
-        else
-            AddonCategory.listLibraries[i] = name
-        end
+	for i = 1, #self.addonTypes[IS_ADDON] do
+		local entryData = self.addonTypes[IS_ADDON][i]
 
-        local entryData = {
-            index = i,
-            addOnFileName = name,
-            addOnName = title,
-            strippedAddOnName = StripText(title),
-            addOnDescription = description,
-            addOnEnabled = enabled,
-            addOnState = state,
-            isOutOfDate = isOutOfDate,
-            isLibrary = isLibrary,
-            isCustomCategory = false,
-            dependsOn = {}
-        }
-		
-		if sV[name] ~= nil then
+		addAddonToList(entryData.index, entryData.addOnFileName, IS_ADDON)
+
+		entryData.isCustomCategory = false
+		if sV[entryData.addOnFileName] ~= nil then
 			entryData.isCustomCategory = true
-        elseif isLibrary ~= IS_LIBRARY then
-            table.insert(AddonCategory.listNonAssigned, name)
 		end
-
-        if author ~= "" then
-            local strippedAuthor = StripText(author)
-            entryData.addOnAuthorByLine = zo_strformat(SI_ADD_ON_AUTHOR_LINE, author)
-            entryData.strippedAddOnAuthorByLine = zo_strformat(SI_ADD_ON_AUTHOR_LINE, strippedAuthor)
-        else
-            entryData.addOnAuthorByLine = ""
-            entryData.strippedAddOnAuthorByLine = ""
-        end
-
-        local dependencyText = ""
-        for j = 1, AddOnManager:GetAddOnNumDependencies(i) do
-            local dependencyName, dependencyExists, dependencyActive, dependencyMinVersion, dependencyVersion = AddOnManager:GetAddOnDependencyInfo(i, j)
-            local dependencyTooLowVersion = dependencyVersion < dependencyMinVersion        
-            
-            local dependencyInfoLine = dependencyName
-            if not self.isAllFilterSelected and (not dependencyActive or not dependencyExists or dependencyTooLowVersion) then
-                entryData.hasDependencyError = true
-                if not dependencyExists then
-                    dependencyInfoLine = zo_strformat(SI_ADDON_MANAGER_DEPENDENCY_MISSING, dependencyName)
-                elseif not dependencyActive then
-                    dependencyInfoLine = zo_strformat(SI_ADDON_MANAGER_DEPENDENCY_DISABLED, dependencyName)
-                elseif dependencyTooLowVersion then
-                    dependencyInfoLine = zo_strformat(SI_ADDON_MANAGER_DEPENDENCY_TOO_LOW_VERSION, dependencyName)
-                end
-                dependencyInfoLine = ZO_ERROR_COLOR:Colorize(dependencyInfoLine)
-            end
-            dependencyText = string.format("%s\n    %s  %s", dependencyText, GetString(SI_BULLET), dependencyInfoLine)
-        end
-        entryData.addOnDependencyText = dependencyText
-
-        entryData.expandable = (description ~= "") or (dependencyText ~= "")
-
+        
         if entryData.isCustomCategory == true then
-            table.insert(self.addonTypes[sV[name]], entryData)
+			self.addonTypes[IS_ADDON][i] = nil
+            table.insert(self.addonTypes[sV[entryData.addOnFileName]], entryData)
         else
-            table.insert(self.addonTypes[isLibrary], entryData)
+            table.insert(self.addonTypes[IS_ADDON], entryData)
         end
     end
+
+	for i = 1, #self.addonTypes[IS_LIBRARY] do
+		local entryData = self.addonTypes[IS_LIBRARY][i]
+		addAddonToList(entryData.index, entryData.addOnFileName, IS_LIBRARY)
+	end
+
+	if votanAddonListPresent == true then
+		--Reset to original sortCallback
+		self.sortCallback = function(entry1, entry2)
+			return ZO_TableOrderingFunction(entry1, entry2, self.currentSortKey, self.sortKeys, self.currentSortDirection)
+		end
+	end
+end
+
+--disable addon indent do by Votan's Addon List because this feature can't work when our addon is enabled
+local function DisableVotanAddonListIndent(control)
+	local indent = 0
+
+	local enableButton = control:GetNamedChild("Enabled")
+	enableButton:SetAnchor(TOPLEFT, nil, TOPLEFT, 7 + indent, 7)
+	
+	local name = control:GetNamedChild("Name")
+	name:SetWidth(385 - indent)
+end
+
+-- Can't use SecurePostHook because need to be called on the callback function returned by GetRowSetupFunction()
+local orgGetRowSetupFunction = ZO_AddOnManager.GetRowSetupFunction
+function ZO_AddOnManager:GetRowSetupFunction()
+	return function(...)
+		local orgSetup = orgGetRowSetupFunction(self)
+		orgSetup(...)
+		
+		if votanAddonListPresent == true then
+			DisableVotanAddonListIndent(...)
+		end
+		
+	end
 end
 
 local libraryText = nil
@@ -333,7 +343,7 @@ local function OnExpandButtonClicked(self, row)
     self:CommitScrollList()
 end
 
-ADD_ON_MANAGER.BuildMasterList = BuildMasterList
+SecurePostHook(ADD_ON_MANAGER, "BuildMasterList", BuildMasterList)
 ADD_ON_MANAGER.AddAddonTypeSection = AddAddonTypeSection
 ADD_ON_MANAGER.SetupSectionHeaderRow = SetupSectionHeaderRow
 ADD_ON_MANAGER.SortScrollList = SortScrollList
@@ -370,13 +380,17 @@ function AddonCategory:Initialize()
 	sV = AddonCategory.savedVariables
 
 	--Settings
-    ADD_ON_MANAGER.BuildMasterList(self)
+	populateList()
 	AddonCategory.CreateSettingsWindow()
 
 	EVENT_MANAGER:UnregisterForEvent(AddonCategory.name, EVENT_ADD_ON_LOADED)
 end
 
 function AddonCategory.OnAddOnLoaded(event, addonName)
+	if addonName == "LibVotansAddonList" then
+		votanAddonListPresent = true
+	end
+
 	if addonName ~= AddonCategory.name then return end
     AddonCategory:Initialize()
 end

--- a/AddonCategory.lua
+++ b/AddonCategory.lua
@@ -71,6 +71,8 @@ local function BuildMasterList(self)
 
     resetList()
 
+	isAddonWithoutNilValues = {}
+
 	for i = 1, #self.addonTypes[IS_ADDON] do
 		local entryData = self.addonTypes[IS_ADDON][i]
 
@@ -85,9 +87,11 @@ local function BuildMasterList(self)
 			self.addonTypes[IS_ADDON][i] = nil
             table.insert(self.addonTypes[sV[entryData.addOnFileName]], entryData)
         else
-            table.insert(self.addonTypes[IS_ADDON], entryData)
+            table.insert(isAddonWithoutNilValues, entryData)
         end
     end
+
+	self.addonTypes[IS_ADDON] = isAddonWithoutNilValues
 
 	for i = 1, #self.addonTypes[IS_LIBRARY] do
 		local entryData = self.addonTypes[IS_LIBRARY][i]


### PR DESCRIPTION
I not sure I fully understand the issue on eosui comments, but there are 2 fixies (in separated commits if you want to check) :
* Fixies about empty "Addon" ZoS category list (because table seem to need to be reset without `nil` values)
* When an AddonCategory's base category has been renamed, when we manually remove it from savedVariable (but I suppose there is the same issue when we install it) an addon which are preassigned to it, there is an error because the category is not found

I also have re-add changes you have revert because I assume you did it to avoid the issue the time to find how to fix that

I'm not sure if the first fix is for the issue reported by `valthierX` and `L4R5` on esoui, but I also use Perfect Pixel and I don't see any issues other than the issue you found with unassigned addon (but also present without Perfect Pixel and Votan's Addons List)
Let me know if the issue is somewhere else, I can search how to fix it if you want